### PR TITLE
relative import not working with ts-node

### DIFF
--- a/Util.ts
+++ b/Util.ts
@@ -1,0 +1,1 @@
+export const log = 5

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
 import ts from "typescript"
+import { log } from "./Util"
 
 console.log(ts.version)
+console.log(log)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "start-ts": "ts-node index",
+    "start-ts-ok": "ts-node --experimental-specifier-resolution=node index",
     "start": "tsc && node index"
   },
   "repository": {


### PR DESCRIPTION
Hey Felipe,
unfortunately it doesn't seem to work for relative imports. I added your mentioned import of 'log' from 'Util' but it results in the infamous
```bash
┏╸~/Code/tmp/esm-examples[main {origin/main}|✚1…2]
┗╸❯❯❯ npm run start-ts                                                                                                                                                            [main {origin/main}|✚1…2]

> esm-examples@1.0.0 start-ts
> ts-node index

/Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:366
    throw new ERR_MODULE_NOT_FOUND(
          ^
CustomError: Cannot find module '/Users/einselbst/Code/tmp/esm-examples/Util' imported from /Users/einselbst/Code/tmp/esm-examples/index.ts
    at finalizeResolution (/Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:366:11)
    at moduleResolve (/Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:801:10)
    at Object.defaultResolve (/Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:912:11)
    at /Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/src/esm.ts:218:35
    at entrypointFallback (/Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/src/esm.ts:168:34)
    at /Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/src/esm.ts:217:14
    at addShortCircuitFlag (/Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/src/esm.ts:409:21)
    at resolve (/Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/src/esm.ts:197:12)
    at resolve (/Users/einselbst/Code/tmp/esm-examples/node_modules/ts-node/src/child/child-loader.ts:15:39)
```

It is working, when using this script command:
`ts-node --experimental-specifier-resolution=node index`

Last but not least, of course it's also working when adding '.js' to the import:
`import { log } from "./Util.js"`

One other idea I had but haven't tested yet was using the path feature of tsconfig to turn relative imports into absolute ones, but I don't know if ts-node respects it.

Please see this section where the difference regarding relative vs non-relative resolution is mentioned: https://www.typescriptlang.org/docs/handbook/module-resolution.html#how-nodejs-resolves-modules